### PR TITLE
Change the order of the drop and create table ddl script

### DIFF
--- a/src/main/resources/db/ddl.sql
+++ b/src/main/resources/db/ddl.sql
@@ -1,9 +1,28 @@
-DROP TABLE IF EXISTS users CASCADE;
 DROP TABLE IF EXISTS roles CASCADE;
-DROP TABLE IF EXISTS orders CASCADE;
-DROP TABLE IF EXISTS products CASCADE;
-DROP TABLE IF EXISTS reviews CASCADE;
 DROP TABLE IF EXISTS departments CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+DROP TABLE IF EXISTS reviews CASCADE;
+
+CREATE TABLE roles (
+    id VARCHAR PRIMARY KEY,
+    name VARCHAR NOT NULL
+);
+
+CREATE TABLE departments (
+    id VARCHAR PRIMARY KEY,
+    name VARCHAR
+);
+
+CREATE TABLE products (
+    id VARCHAR PRIMARY KEY,
+    name VARCHAR,
+    price VARCHAR,
+    on_hand VARCHAR,
+    departments_id VARCHAR,
+    FOREIGN KEY (departments_id) REFERENCES departments (id)
+);
 
 CREATE TABLE users (
     id VARCHAR PRIMARY KEY,
@@ -11,11 +30,6 @@ CREATE TABLE users (
     password VARCHAR NOT NULL,
     roles_id VARCHAR NOT NULL,
     FOREIGN KEY (roles_id) REFERENCES roles (id)
-);
-
-CREATE TABLE roles (
-    id VARCHAR PRIMARY KEY,
-    name VARCHAR NOT NULL
 );
 
 CREATE TABLE orders (
@@ -28,15 +42,6 @@ CREATE TABLE orders (
     FOREIGN KEY (product_id) REFERENCES products (id)
 );
 
-CREATE TABLE products (
-    id VARCHAR PRIMARY KEY,
-    name VARCHAR,
-    price VARCHAR,
-    on_hand VARCHAR,
-    departments_id VARCHAR,
-    FOREIGN KEY (departments_id) REFERENCES departments (id)
-);
-
 CREATE TABLE reviews (
     id VARCHAR PRIMARY KEY,
     comment VARCHAR,
@@ -45,9 +50,4 @@ CREATE TABLE reviews (
     product_id VARCHAR NOT NULL,
     FOREIGN KEY (user_id) REFERENCES users (id),
     FOREIGN KEY (product_id) REFERENCES products (id)
-);
-
-CREATE TABLE departments (
-    id VARCHAR PRIMARY KEY,
-    name VARCHAR
 );


### PR DESCRIPTION
The previous order resulted in errors when running the ddl script because the table(s) did not exist yet or had not been created before the relationships were defined; 

Users could not be created because roles did not yet exist, so roles table was moved before users table - for example.

So I repositioned the order of some tables so the script could be run as is.
